### PR TITLE
deploy: K3s 기반 Jenkins, Prometheus, Grafana, Dashboard 배포 yaml 추가

### DIFF
--- a/deploy/k8s/dashboard/dashboard-admin.yaml
+++ b/deploy/k8s/dashboard/dashboard-admin.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: admin-user
+  namespace: kubernetes-dashboard

--- a/deploy/k8s/dashboard/dashboard-service.yaml
+++ b/deploy/k8s/dashboard/dashboard-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dashboard-nodeport
+  namespace: kubernetes-dashboard
+spec:
+  type: NodePort
+  selector:
+    k8s-app: kubernetes-dashboard
+  ports:
+  - port: 443
+    targetPort: 8443
+    nodePort: 30443

--- a/deploy/k8s/jenkins/deployment.yaml
+++ b/deploy/k8s/jenkins/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jenkins
+  namespace: jenkins
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jenkins
+  template:
+    metadata:
+      labels:
+        app: jenkins
+    spec:
+      containers:
+      - name: jenkins
+        image: jenkins/jenkins:lts
+        ports:
+        - containerPort: 8080
+        - containerPort: 50000
+        volumeMounts:
+        - name: jenkins-data
+          mountPath: /var/jenkins_home
+      volumes:
+      - name: jenkins-data
+        hostPath:
+          path: /opt/jenkins-data
+          type: DirectoryOrCreate

--- a/deploy/k8s/jenkins/service.yaml
+++ b/deploy/k8s/jenkins/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jenkins
+  namespace: jenkins
+spec:
+  type: NodePort
+  selector:
+    app: jenkins
+  ports:
+  - name: web
+    port: 8080
+    targetPort: 8080
+    nodePort: 30080
+  - name: agent
+    port: 50000
+    targetPort: 50000

--- a/deploy/k8s/monitoring/grafana-deployment.yaml
+++ b/deploy/k8s/monitoring/grafana-deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - name: grafana
+        image: grafana/grafana:latest
+        ports:
+        - containerPort: 3000
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/grafana
+      volumes:
+      - name: data
+        hostPath:
+          path: /opt/grafana-data
+          type: DirectoryOrCreate

--- a/deploy/k8s/monitoring/grafana-service.yaml
+++ b/deploy/k8s/monitoring/grafana-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  type: NodePort
+  selector:
+    app: grafana
+  ports:
+  - port: 3000
+    targetPort: 3000
+    nodePort: 30030

--- a/deploy/k8s/monitoring/prometheus-config.yaml
+++ b/deploy/k8s/monitoring/prometheus-config.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: monitoring
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+      - job_name: 'kubernetes-pods'
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            target_label: __address__
+            regex: (.+)
+            replacement: ${1}

--- a/deploy/k8s/monitoring/prometheus-deployment.yaml
+++ b/deploy/k8s/monitoring/prometheus-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+      - name: prometheus
+        image: prom/prometheus:latest
+        ports:
+        - containerPort: 9090
+        volumeMounts:
+        - name: config
+          mountPath: /etc/prometheus
+        - name: data
+          mountPath: /prometheus
+      volumes:
+      - name: config
+        configMap:
+          name: prometheus-config
+      - name: data
+        hostPath:
+          path: /opt/prometheus-data
+          type: DirectoryOrCreate

--- a/deploy/k8s/monitoring/prometheus-service.yaml
+++ b/deploy/k8s/monitoring/prometheus-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  type: NodePort
+  selector:
+    app: prometheus
+  ports:
+  - port: 9090
+    targetPort: 9090
+    nodePort: 30090


### PR DESCRIPTION
## 📋 PR 유형
- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 테스트 추가 (test)
- [x] 설정/빌드 (chore)

## 🎯 작업 내용
K3s 클러스터 기반 인프라 배포 yaml 추가
- Jenkins (CI/CD): deployment, service (NodePort 30080)
- Prometheus (모니터링): config, deployment, service (NodePort 30090)
- Grafana (시각화): deployment, service (NodePort 30030)
- Kubernetes Dashboard: service, admin 계정 설정 (NodePort 30443)

## 🔗 관련 이슈

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [x] 코드 컨벤션 준수

## 📸 스크린샷 (선택)
- Jenkins: `http://10.10.10.100:30080` 접속 확인

<img width="934" height="954" alt="{4EFB1F6B-410E-4B23-AF8D-9AEF4B1668C9}" src="https://github.com/user-attachments/assets/81f2defb-8d65-4771-bc67-d1b35c858b7a" />

- Prometheus: `http://10.10.10.100:30090` 접속 확인

<img width="951" height="575" alt="{26BF7DB6-FBB7-4278-A667-8F8A52378A07}" src="https://github.com/user-attachments/assets/12969bfb-c866-4dfe-894b-7c9d9c51cab4" />

- Grafana: `http://10.10.10.100:30030` 접속 확인

<img width="946" height="816" alt="{94F856D9-1F0B-4388-8973-96A957A6384E}" src="https://github.com/user-attachments/assets/073d93b1-3bb0-43a1-9772-0260ea80b5fd" />


- K8s Dashboard: `https://10.10.10.100:30443` 접속 확인

<img width="953" height="869" alt="{88F8563F-E967-481F-B694-61D12D0D0301}" src="https://github.com/user-attachments/assets/78909f45-b136-4d30-89d7-b61eead53987" />
