### PR TITLE
deploy(k3s): K3s 서비스 배포 yaml 13개 추가 (Rolling Update 무중단 배포)

### DIFF
--- a/deploy/k3s/services/admin-audit.yaml
+++ b/deploy/k3s/services/admin-audit.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: corebridge-admin-audit
+  namespace: corebridge
+  labels:
+    app: corebridge-admin-audit
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: corebridge-admin-audit
+  template:
+    metadata:
+      labels:
+        app: corebridge-admin-audit
+    spec:
+      containers:
+        - name: admin-audit
+          image: atimaby12/corebridge-admin-audit:latest
+          ports:
+            - containerPort: 8013
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8013
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8013
+            initialDelaySeconds: 60
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: corebridge-admin-audit
+  namespace: corebridge
+spec:
+  type: ClusterIP
+  selector:
+    app: corebridge-admin-audit
+  ports:
+    - port: 8013
+      targetPort: 8013

--- a/deploy/k3s/services/apply.yaml
+++ b/deploy/k3s/services/apply.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: corebridge-apply
+  namespace: corebridge
+  labels:
+    app: corebridge-apply
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: corebridge-apply
+  template:
+    metadata:
+      labels:
+        app: corebridge-apply
+    spec:
+      containers:
+        - name: apply
+          image: atimaby12/corebridge-apply:latest
+          ports:
+            - containerPort: 8009
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8009
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8009
+            initialDelaySeconds: 60
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: corebridge-apply
+  namespace: corebridge
+spec:
+  type: ClusterIP
+  selector:
+    app: corebridge-apply
+  ports:
+    - port: 8009
+      targetPort: 8009

--- a/deploy/k3s/services/gateway.yaml
+++ b/deploy/k3s/services/gateway.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: corebridge-gateway
+  namespace: corebridge
+  labels:
+    app: corebridge-gateway
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: corebridge-gateway
+  template:
+    metadata:
+      labels:
+        app: corebridge-gateway
+    spec:
+      containers:
+        - name: gateway
+          image: atimaby12/corebridge-gateway:latest
+          ports:
+            - containerPort: 8000
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8000
+            initialDelaySeconds: 60
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: corebridge-gateway
+  namespace: corebridge
+spec:
+  type: NodePort
+  selector:
+    app: corebridge-gateway
+  ports:
+    - port: 8000
+      targetPort: 8000
+      nodePort: 30081

--- a/deploy/k3s/services/jobposting-comment.yaml
+++ b/deploy/k3s/services/jobposting-comment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: corebridge-jobposting-comment
+  namespace: corebridge
+  labels:
+    app: corebridge-jobposting-comment
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: corebridge-jobposting-comment
+  template:
+    metadata:
+      labels:
+        app: corebridge-jobposting-comment
+    spec:
+      containers:
+        - name: jobposting-comment
+          image: atimaby12/corebridge-jobposting-comment:latest
+          ports:
+            - containerPort: 8003
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8003
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8003
+            initialDelaySeconds: 60
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: corebridge-jobposting-comment
+  namespace: corebridge
+spec:
+  type: ClusterIP
+  selector:
+    app: corebridge-jobposting-comment
+  ports:
+    - port: 8003
+      targetPort: 8003

--- a/deploy/k3s/services/jobposting-hot.yaml
+++ b/deploy/k3s/services/jobposting-hot.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: corebridge-jobposting-hot
+  namespace: corebridge
+  labels:
+    app: corebridge-jobposting-hot
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: corebridge-jobposting-hot
+  template:
+    metadata:
+      labels:
+        app: corebridge-jobposting-hot
+    spec:
+      containers:
+        - name: jobposting-hot
+          image: atimaby12/corebridge-jobposting-hot:latest
+          ports:
+            - containerPort: 8006
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8006
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8006
+            initialDelaySeconds: 60
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: corebridge-jobposting-hot
+  namespace: corebridge
+spec:
+  type: ClusterIP
+  selector:
+    app: corebridge-jobposting-hot
+  ports:
+    - port: 8006
+      targetPort: 8006

--- a/deploy/k3s/services/jobposting-like.yaml
+++ b/deploy/k3s/services/jobposting-like.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: corebridge-jobposting-like
+  namespace: corebridge
+  labels:
+    app: corebridge-jobposting-like
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: corebridge-jobposting-like
+  template:
+    metadata:
+      labels:
+        app: corebridge-jobposting-like
+    spec:
+      containers:
+        - name: jobposting-like
+          image: atimaby12/corebridge-jobposting-like:latest
+          ports:
+            - containerPort: 8005
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8005
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8005
+            initialDelaySeconds: 60
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: corebridge-jobposting-like
+  namespace: corebridge
+spec:
+  type: ClusterIP
+  selector:
+    app: corebridge-jobposting-like
+  ports:
+    - port: 8005
+      targetPort: 8005

--- a/deploy/k3s/services/jobposting-read.yaml
+++ b/deploy/k3s/services/jobposting-read.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: corebridge-jobposting-read
+  namespace: corebridge
+  labels:
+    app: corebridge-jobposting-read
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: corebridge-jobposting-read
+  template:
+    metadata:
+      labels:
+        app: corebridge-jobposting-read
+    spec:
+      containers:
+        - name: jobposting-read
+          image: atimaby12/corebridge-jobposting-read:latest
+          ports:
+            - containerPort: 8007
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8007
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8007
+            initialDelaySeconds: 60
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: corebridge-jobposting-read
+  namespace: corebridge
+spec:
+  type: ClusterIP
+  selector:
+    app: corebridge-jobposting-read
+  ports:
+    - port: 8007
+      targetPort: 8007

--- a/deploy/k3s/services/jobposting-view.yaml
+++ b/deploy/k3s/services/jobposting-view.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: corebridge-jobposting-view
+  namespace: corebridge
+  labels:
+    app: corebridge-jobposting-view
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: corebridge-jobposting-view
+  template:
+    metadata:
+      labels:
+        app: corebridge-jobposting-view
+    spec:
+      containers:
+        - name: jobposting-view
+          image: atimaby12/corebridge-jobposting-view:latest
+          ports:
+            - containerPort: 8004
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8004
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8004
+            initialDelaySeconds: 60
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: corebridge-jobposting-view
+  namespace: corebridge
+spec:
+  type: ClusterIP
+  selector:
+    app: corebridge-jobposting-view
+  ports:
+    - port: 8004
+      targetPort: 8004

--- a/deploy/k3s/services/jobposting.yaml
+++ b/deploy/k3s/services/jobposting.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: corebridge-jobposting
+  namespace: corebridge
+  labels:
+    app: corebridge-jobposting
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: corebridge-jobposting
+  template:
+    metadata:
+      labels:
+        app: corebridge-jobposting
+    spec:
+      containers:
+        - name: jobposting
+          image: atimaby12/corebridge-jobposting:latest
+          ports:
+            - containerPort: 8002
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8002
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8002
+            initialDelaySeconds: 60
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: corebridge-jobposting
+  namespace: corebridge
+spec:
+  type: ClusterIP
+  selector:
+    app: corebridge-jobposting
+  ports:
+    - port: 8002
+      targetPort: 8002

--- a/deploy/k3s/services/notification.yaml
+++ b/deploy/k3s/services/notification.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: corebridge-notification
+  namespace: corebridge
+  labels:
+    app: corebridge-notification
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: corebridge-notification
+  template:
+    metadata:
+      labels:
+        app: corebridge-notification
+    spec:
+      containers:
+        - name: notification
+          image: atimaby12/corebridge-notification:latest
+          ports:
+            - containerPort: 8011
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8011
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8011
+            initialDelaySeconds: 60
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: corebridge-notification
+  namespace: corebridge
+spec:
+  type: ClusterIP
+  selector:
+    app: corebridge-notification
+  ports:
+    - port: 8011
+      targetPort: 8011

--- a/deploy/k3s/services/resume.yaml
+++ b/deploy/k3s/services/resume.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: corebridge-resume
+  namespace: corebridge
+  labels:
+    app: corebridge-resume
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: corebridge-resume
+  template:
+    metadata:
+      labels:
+        app: corebridge-resume
+    spec:
+      containers:
+        - name: resume
+          image: atimaby12/corebridge-resume:latest
+          ports:
+            - containerPort: 8008
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8008
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8008
+            initialDelaySeconds: 60
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: corebridge-resume
+  namespace: corebridge
+spec:
+  type: ClusterIP
+  selector:
+    app: corebridge-resume
+  ports:
+    - port: 8008
+      targetPort: 8008

--- a/deploy/k3s/services/schedule.yaml
+++ b/deploy/k3s/services/schedule.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: corebridge-schedule
+  namespace: corebridge
+  labels:
+    app: corebridge-schedule
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: corebridge-schedule
+  template:
+    metadata:
+      labels:
+        app: corebridge-schedule
+    spec:
+      containers:
+        - name: schedule
+          image: atimaby12/corebridge-schedule:latest
+          ports:
+            - containerPort: 8012
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8012
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8012
+            initialDelaySeconds: 60
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: corebridge-schedule
+  namespace: corebridge
+spec:
+  type: ClusterIP
+  selector:
+    app: corebridge-schedule
+  ports:
+    - port: 8012
+      targetPort: 8012

--- a/deploy/k3s/services/user.yaml
+++ b/deploy/k3s/services/user.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: corebridge-user
+  namespace: corebridge
+  labels:
+    app: corebridge-user
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: corebridge-user
+  template:
+    metadata:
+      labels:
+        app: corebridge-user
+    spec:
+      containers:
+        - name: user
+          image: atimaby12/corebridge-user:latest
+          ports:
+            - containerPort: 8001
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8001
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8001
+            initialDelaySeconds: 60
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: corebridge-user
+  namespace: corebridge
+spec:
+  type: ClusterIP
+  selector:
+    app: corebridge-user
+  ports:
+    - port: 8001
+      targetPort: 8001


### PR DESCRIPTION
## 📋 PR 유형
- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 테스트 추가 (test)
- [x] 설정/빌드 (chore)

## 🎯 작업 내용
K3s 서비스 배포용 yaml 13개 추가

**추가된 파일 (deploy/k3s/services/):**
- gateway.yaml (8000 → NodePort 30081)
- user.yaml (8001)
- jobposting.yaml (8002)
- jobposting-comment.yaml (8003)
- jobposting-view.yaml (8004)
- jobposting-like.yaml (8005)
- jobposting-hot.yaml (8006)
- jobposting-read.yaml (8007)
- resume.yaml (8008)
- apply.yaml (8009)
- notification.yaml (8011)
- schedule.yaml (8012)
- admin-audit.yaml (8013)

**배포 전략:**
- Rolling Update (무중단 배포)
- maxSurge: 1, maxUnavailable: 0
- Readiness/Liveness Probe 설정
- Resource limits/requests 설정

## 🔗 관련 이슈

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [x] 코드 컨벤션 준수

## 📸 스크린샷 (선택)
- Gateway Pod Running 확인
- Jenkins CI/CD 파이프라인 성공
- Rolling Update 무중단 배포 확인

<img width="1569" height="483" alt="{004F8E04-CD28-4D18-84A5-BD4DBF36088B}" src="https://github.com/user-attachments/assets/09463618-8b36-4a78-a8fd-7a338a8fb134" />
