### PR TITLE
fix: Event 역직렬화 버그 수정 및 AuditDto 기본 생성자 추가

### DIFF
--- a/backend/common/src/main/java/halo/corebridge/common/event/Event.java
+++ b/backend/common/src/main/java/halo/corebridge/common/event/Event.java
@@ -1,13 +1,17 @@
 package halo.corebridge.common.event;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
 @ToString
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Event<T extends EventPayload> {
     private EventType type;
-    private T payload;
+    private Object payload;
 
     public static <T extends EventPayload> Event<T> of(EventType type, T payload) {
         Event<T> event = new Event<>();

--- a/backend/service/admin-audit/src/main/java/halo/corebridge/adminaudit/model/dto/AuditDto.java
+++ b/backend/service/admin-audit/src/main/java/halo/corebridge/adminaudit/model/dto/AuditDto.java
@@ -2,8 +2,7 @@ package halo.corebridge.adminaudit.model.dto;
 
 import halo.corebridge.adminaudit.model.entity.AuditLog;
 import halo.corebridge.adminaudit.model.enums.AuditEventType;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,6 +15,8 @@ public class AuditDto {
 
     @Getter
     @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
     public static class CreateRequest {
         private Long userId;
         private String userEmail;
@@ -33,6 +34,8 @@ public class AuditDto {
 
     @Getter
     @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
     public static class SearchRequest {
         private Long userId;
         private String serviceName;

--- a/backend/service/jobposting-hot/src/main/java/halo/corebridge/jobpostinghot/handler/HotJobpostingEventHandler.java
+++ b/backend/service/jobposting-hot/src/main/java/halo/corebridge/jobpostinghot/handler/HotJobpostingEventHandler.java
@@ -39,7 +39,7 @@ public class HotJobpostingEventHandler implements EventHandler<EventPayload> {
     @Transactional
     public void handle(Event<EventPayload> event) {
         EventType type = event.getType();
-        EventPayload payload = event.getPayload();
+        EventPayload payload = (EventPayload) event.getPayload();
 
         switch (type) {
             case JOBPOSTING_CREATED -> handleCreated((JobpostingCreatedEventPayload) payload);

--- a/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/handler/CommentCreatedEventHandler.java
+++ b/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/handler/CommentCreatedEventHandler.java
@@ -17,7 +17,7 @@ public class CommentCreatedEventHandler implements EventHandler<CommentCreatedEv
 
     @Override
     public void handle(Event<CommentCreatedEventPayload> event) {
-        CommentCreatedEventPayload payload = event.getPayload();
+        CommentCreatedEventPayload payload = (CommentCreatedEventPayload) event.getPayload();
         readCache.incrementCommentCount(payload.getJobpostingId());
         log.info("[ReadHandler] COMMENT_CREATED: jobpostingId={}", payload.getJobpostingId());
     }

--- a/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/handler/CommentDeletedEventHandler.java
+++ b/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/handler/CommentDeletedEventHandler.java
@@ -17,7 +17,7 @@ public class CommentDeletedEventHandler implements EventHandler<CommentDeletedEv
 
     @Override
     public void handle(Event<CommentDeletedEventPayload> event) {
-        CommentDeletedEventPayload payload = event.getPayload();
+        CommentDeletedEventPayload payload = (CommentDeletedEventPayload) event.getPayload();
         readCache.decrementCommentCount(payload.getJobpostingId());
         log.info("[ReadHandler] COMMENT_DELETED: jobpostingId={}", payload.getJobpostingId());
     }

--- a/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/handler/JobpostingDeletedEventHandler.java
+++ b/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/handler/JobpostingDeletedEventHandler.java
@@ -17,7 +17,7 @@ public class JobpostingDeletedEventHandler implements EventHandler<JobpostingDel
 
     @Override
     public void handle(Event<JobpostingDeletedEventPayload> event) {
-        JobpostingDeletedEventPayload payload = event.getPayload();
+        JobpostingDeletedEventPayload payload = (JobpostingDeletedEventPayload) event.getPayload();
         readCache.removeJobposting(payload.getJobpostingId());
         log.info("[ReadHandler] JOBPOSTING_DELETED: jobpostingId={}", payload.getJobpostingId());
     }

--- a/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/handler/JobpostingLikedEventHandler.java
+++ b/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/handler/JobpostingLikedEventHandler.java
@@ -17,7 +17,7 @@ public class JobpostingLikedEventHandler implements EventHandler<JobpostingLiked
 
     @Override
     public void handle(Event<JobpostingLikedEventPayload> event) {
-        JobpostingLikedEventPayload payload = event.getPayload();
+        JobpostingLikedEventPayload payload = (JobpostingLikedEventPayload) event.getPayload();
         readCache.updateLikeCount(payload.getJobpostingId(), payload.getLikeCount());
         log.info("[ReadHandler] JOBPOSTING_LIKED: jobpostingId={}, likeCount={}",
                 payload.getJobpostingId(), payload.getLikeCount());

--- a/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/handler/JobpostingUnlikedEventHandler.java
+++ b/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/handler/JobpostingUnlikedEventHandler.java
@@ -17,7 +17,7 @@ public class JobpostingUnlikedEventHandler implements EventHandler<JobpostingUnl
 
     @Override
     public void handle(Event<JobpostingUnlikedEventPayload> event) {
-        JobpostingUnlikedEventPayload payload = event.getPayload();
+        JobpostingUnlikedEventPayload payload = (JobpostingUnlikedEventPayload) event.getPayload();
         readCache.updateLikeCount(payload.getJobpostingId(), payload.getLikeCount());
         log.info("[ReadHandler] JOBPOSTING_UNLIKED: jobpostingId={}, likeCount={}",
                 payload.getJobpostingId(), payload.getLikeCount());

--- a/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/handler/JobpostingViewedEventHandler.java
+++ b/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/handler/JobpostingViewedEventHandler.java
@@ -17,7 +17,7 @@ public class JobpostingViewedEventHandler implements EventHandler<JobpostingView
 
     @Override
     public void handle(Event<JobpostingViewedEventPayload> event) {
-        JobpostingViewedEventPayload payload = event.getPayload();
+        JobpostingViewedEventPayload payload = (JobpostingViewedEventPayload) event.getPayload();
         readCache.updateViewCount(payload.getJobpostingId(), payload.getViewCount());
         log.info("[ReadHandler] JOBPOSTING_VIEWED: jobpostingId={}, viewCount={}",
                 payload.getJobpostingId(), payload.getViewCount());


### PR DESCRIPTION
## 📋 PR 유형
- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 테스트 추가 (test)
- [ ] 설정/빌드 (chore)

## 🎯 작업 내용
Outbox → Kafka → Consumer 흐름에서 발생한 역직렬화 버그 수정

- **Event.java**: `payload` 필드의 Jackson 역직렬화를 위한 타입 정보 추가
- **AuditDto.CreateRequest**: `@NoArgsConstructor` 추가 — Gateway → admin-audit POST 요청 시 Jackson 역직렬화 실패(500 에러) 해결
- **jobposting-read handlers (6개)**: `EventPayload` 추상 클래스 캐스팅 오류 수정 — `Cannot construct instance of EventPayload` 해결
- **jobposting-hot handler**: 동일 캐스팅 수정

### 수정 전 증상
- Consumer에서 `received message` 후 역직렬화 실패 → 이벤트 처리 불가
- admin-audit 서비스 500 에러 (`서버 내부 오류입니다`)

### 수정 후 결과
- Outbox 이벤트 생성 → Kafka 발행 → Consumer 수신 → ReadCache 업데이트 E2E 정상 동작
- JOBPOSTING_CREATED, JOBPOSTING_VIEWED, JOBPOSTING_DELETED 전체 이벤트 타입 처리 확인

## 🔗 관련 이슈

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [x] 코드 컨벤션 준수

## 📸 스크린샷

<img width="1216" height="249" alt="제목 없음1" src="https://github.com/user-attachments/assets/7308931b-1c8a-4647-a8f0-4539fd019b3c" />

<img width="1238" height="95" alt="제목 없음2" src="https://github.com/user-attachments/assets/5380afe5-caac-4866-ab93-8effe711fe72" />

<img width="1235" height="155" alt="제목 없음3" src="https://github.com/user-attachments/assets/e0167ab0-cfb6-4e2d-bc81-1722f961c403" />

<img width="1077" height="266" alt="제목 없음4" src="https://github.com/user-attachments/assets/ff89ffd5-4dd5-4a49-b18a-65fd2b674d85" />
