### PR TITLE
feat(circuit-breaker): jobposting-read 서비스에 Resilience4j Circuit Brea…

### DIFF
--- a/backend/service/jobposting-read/build.gradle
+++ b/backend/service/jobposting-read/build.gradle
@@ -19,6 +19,11 @@ dependencies {
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // Resilience4j Circuit Breaker
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/client/CommentClient.java
+++ b/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/client/CommentClient.java
@@ -1,12 +1,13 @@
 package halo.corebridge.jobpostingread.client;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.Map;
-
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CommentClient {
@@ -16,18 +17,22 @@ public class CommentClient {
     @Value("${client.comment.url:http://localhost:8003}")
     private String commentServiceUrl;
 
+    @CircuitBreaker(name = "commentService", fallbackMethod = "countFallback")
     public Long count(Long jobpostingId) {
-        try {
-            String url = String.format("%s/api/v1/comments?jobpostingId=%d&page=1&pageSize=1",
-                    commentServiceUrl, jobpostingId);
-            BaseResponse response = restTemplate.getForObject(url, BaseResponse.class);
-            if (response != null && response.getResult() != null) {
-                return response.getResult().getCommentCount();
-            }
-            return 0L;
-        } catch (Exception e) {
-            return 0L;
+        String url = String.format("%s/api/v1/comments?jobpostingId=%d&page=1&pageSize=1",
+                commentServiceUrl, jobpostingId);
+        BaseResponse response = restTemplate.getForObject(url, BaseResponse.class);
+        if (response != null && response.getResult() != null) {
+            return response.getResult().getCommentCount();
         }
+        return 0L;
+    }
+
+    // ===== Fallback Methods =====
+
+    private Long countFallback(Long jobpostingId, Throwable t) {
+        log.warn("[CircuitBreaker] commentService.count FALLBACK - jobpostingId={}, error={}", jobpostingId, t.getMessage());
+        return 0L;
     }
 
     @lombok.Data

--- a/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/client/JobpostingClient.java
+++ b/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/client/JobpostingClient.java
@@ -1,14 +1,16 @@
 package halo.corebridge.jobpostingread.client;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JobpostingClient {
@@ -18,12 +20,14 @@ public class JobpostingClient {
     @Value("${client.jobposting.url:http://localhost:8002}")
     private String jobpostingServiceUrl;
 
+    @CircuitBreaker(name = "jobpostingService", fallbackMethod = "readFallback")
     public JobpostingResponse read(Long jobpostingId) {
         String url = jobpostingServiceUrl + "/api/v1/jobpostings/" + jobpostingId;
         BaseResponse response = restTemplate.getForObject(url, BaseResponse.class);
         return response != null ? response.getResult() : null;
     }
 
+    @CircuitBreaker(name = "jobpostingService", fallbackMethod = "readAllFallback")
     public JobpostingPageResponse readAll(Long boardId, Long page, Long pageSize) {
         String url = String.format("%s/api/v1/jobpostings?boardId=%d&page=%d&pageSize=%d",
                 jobpostingServiceUrl, boardId, page, pageSize);
@@ -31,14 +35,28 @@ public class JobpostingClient {
         return response != null ? response.getResult() : null;
     }
 
+    @CircuitBreaker(name = "jobpostingService", fallbackMethod = "countFallback")
     public Long count(Long boardId) {
         String url = jobpostingServiceUrl + "/api/v1/jobpostings/boards/" + boardId + "/count";
-        try {
-            BaseCountResponse response = restTemplate.getForObject(url, BaseCountResponse.class);
-            return response != null && response.getResult() != null ? response.getResult() : 0L;
-        } catch (Exception e) {
-            return 0L;
-        }
+        BaseCountResponse response = restTemplate.getForObject(url, BaseCountResponse.class);
+        return response != null && response.getResult() != null ? response.getResult() : 0L;
+    }
+
+    // ===== Fallback Methods =====
+
+    private JobpostingResponse readFallback(Long jobpostingId, Throwable t) {
+        log.warn("[CircuitBreaker] jobpostingService.read FALLBACK - jobpostingId={}, error={}", jobpostingId, t.getMessage());
+        return null;
+    }
+
+    private JobpostingPageResponse readAllFallback(Long boardId, Long page, Long pageSize, Throwable t) {
+        log.warn("[CircuitBreaker] jobpostingService.readAll FALLBACK - boardId={}, error={}", boardId, t.getMessage());
+        return null;
+    }
+
+    private Long countFallback(Long boardId, Throwable t) {
+        log.warn("[CircuitBreaker] jobpostingService.count FALLBACK - boardId={}, error={}", boardId, t.getMessage());
+        return 0L;
     }
 
     // BaseResponse Wrappers

--- a/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/client/LikeClient.java
+++ b/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/client/LikeClient.java
@@ -1,10 +1,13 @@
 package halo.corebridge.jobpostingread.client;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class LikeClient {
@@ -14,14 +17,18 @@ public class LikeClient {
     @Value("${client.like.url:http://localhost:8005}")
     private String likeServiceUrl;
 
+    @CircuitBreaker(name = "likeService", fallbackMethod = "countFallback")
     public Long count(Long jobpostingId) {
-        try {
-            String url = likeServiceUrl + "/api/v1/jobposting-likes/jobpostings/" + jobpostingId + "/count";
-            BaseResponse response = restTemplate.getForObject(url, BaseResponse.class);
-            return response != null && response.getResult() != null ? response.getResult() : 0L;
-        } catch (Exception e) {
-            return 0L;
-        }
+        String url = likeServiceUrl + "/api/v1/jobposting-likes/jobpostings/" + jobpostingId + "/count";
+        BaseResponse response = restTemplate.getForObject(url, BaseResponse.class);
+        return response != null && response.getResult() != null ? response.getResult() : 0L;
+    }
+
+    // ===== Fallback Methods =====
+
+    private Long countFallback(Long jobpostingId, Throwable t) {
+        log.warn("[CircuitBreaker] likeService.count FALLBACK - jobpostingId={}, error={}", jobpostingId, t.getMessage());
+        return 0L;
     }
 
     @lombok.Data

--- a/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/client/UserClient.java
+++ b/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/client/UserClient.java
@@ -1,10 +1,13 @@
 package halo.corebridge.jobpostingread.client;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class UserClient {
@@ -14,22 +17,39 @@ public class UserClient {
     @Value("${client.user.url:http://localhost:8001}")
     private String userServiceUrl;
 
+    @CircuitBreaker(name = "userService", fallbackMethod = "readFallback")
     public UserResponse read(Long userId) {
         if (userId == null) {
             return null;
         }
-        try {
-            String url = userServiceUrl + "/api/v1/users/" + userId;
-            BaseResponse response = restTemplate.getForObject(url, BaseResponse.class);
-            return response != null ? response.getResult() : null;
-        } catch (Exception e) {
-            return null;
-        }
+        String url = userServiceUrl + "/api/v1/users/" + userId;
+        BaseResponse response = restTemplate.getForObject(url, BaseResponse.class);
+        return response != null ? response.getResult() : null;
     }
 
+    @CircuitBreaker(name = "userService", fallbackMethod = "getNicknameFallback")
     public String getNickname(Long userId) {
-        UserResponse user = read(userId);
-        return user != null ? user.getNickname() : "익명";
+        if (userId == null) {
+            return "익명";
+        }
+        String url = userServiceUrl + "/api/v1/users/" + userId;
+        BaseResponse response = restTemplate.getForObject(url, BaseResponse.class);
+        if (response != null && response.getResult() != null) {
+            return response.getResult().getNickname();
+        }
+        return "익명";
+    }
+
+    // ===== Fallback Methods =====
+
+    private UserResponse readFallback(Long userId, Throwable t) {
+        log.warn("[CircuitBreaker] userService.read FALLBACK - userId={}, error={}", userId, t.getMessage());
+        return null;
+    }
+
+    private String getNicknameFallback(Long userId, Throwable t) {
+        log.warn("[CircuitBreaker] userService.getNickname FALLBACK - userId={}, error={}", userId, t.getMessage());
+        return "익명";
     }
 
     @lombok.Data

--- a/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/client/ViewClient.java
+++ b/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/client/ViewClient.java
@@ -1,10 +1,13 @@
 package halo.corebridge.jobpostingread.client;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ViewClient {
@@ -14,14 +17,18 @@ public class ViewClient {
     @Value("${client.view.url:http://localhost:8004}")
     private String viewServiceUrl;
 
+    @CircuitBreaker(name = "viewService", fallbackMethod = "countFallback")
     public Long count(Long jobpostingId) {
-        try {
-            String url = viewServiceUrl + "/api/v1/jobposting-views/jobpostings/" + jobpostingId + "/count";
-            BaseResponse response = restTemplate.getForObject(url, BaseResponse.class);
-            return response != null && response.getResult() != null ? response.getResult() : 0L;
-        } catch (Exception e) {
-            return 0L;
-        }
+        String url = viewServiceUrl + "/api/v1/jobposting-views/jobpostings/" + jobpostingId + "/count";
+        BaseResponse response = restTemplate.getForObject(url, BaseResponse.class);
+        return response != null && response.getResult() != null ? response.getResult() : 0L;
+    }
+
+    // ===== Fallback Methods =====
+
+    private Long countFallback(Long jobpostingId, Throwable t) {
+        log.warn("[CircuitBreaker] viewService.count FALLBACK - jobpostingId={}, error={}", jobpostingId, t.getMessage());
+        return 0L;
     }
 
     @lombok.Data

--- a/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/config/CircuitBreakerEventConfig.java
+++ b/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/config/CircuitBreakerEventConfig.java
@@ -1,0 +1,49 @@
+package halo.corebridge.jobpostingread.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.circuitbreaker.event.CircuitBreakerOnStateTransitionEvent;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class CircuitBreakerEventConfig {
+
+    private final CircuitBreakerRegistry circuitBreakerRegistry;
+
+    @PostConstruct
+    public void registerEventListeners() {
+        circuitBreakerRegistry.getAllCircuitBreakers().forEach(this::registerListener);
+
+        // 동적으로 생성되는 Circuit Breaker도 감지
+        circuitBreakerRegistry.getEventPublisher()
+                .onEntryAdded(event -> registerListener(event.getAddedEntry()));
+    }
+
+    private void registerListener(CircuitBreaker circuitBreaker) {
+        String name = circuitBreaker.getName();
+
+        circuitBreaker.getEventPublisher()
+                .onStateTransition(event -> logStateTransition(name, event))
+                .onError(event -> log.debug(
+                        "[CircuitBreaker] {} ERROR - duration={}ms, error={}",
+                        name, event.getElapsedDuration().toMillis(), event.getThrowable().getMessage()))
+                .onSuccess(event -> log.debug(
+                        "[CircuitBreaker] {} SUCCESS - duration={}ms",
+                        name, event.getElapsedDuration().toMillis()))
+                .onCallNotPermitted(event -> log.warn(
+                        "[CircuitBreaker] {} CALL_NOT_PERMITTED - circuit is OPEN, request rejected",
+                        name));
+    }
+
+    private void logStateTransition(String name, CircuitBreakerOnStateTransitionEvent event) {
+        log.warn("========================================");
+        log.warn("[CircuitBreaker] {} STATE TRANSITION: {} -> {}",
+                name, event.getStateTransition().getFromState(), event.getStateTransition().getToState());
+        log.warn("========================================");
+    }
+}

--- a/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/config/SecurityConfig.java
+++ b/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET, "/api/v1/jobposting-read/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/circuit-breakers/**").permitAll()
                         .requestMatchers("/actuator/**", "/health/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/controller/CircuitBreakerController.java
+++ b/backend/service/jobposting-read/src/main/java/halo/corebridge/jobpostingread/controller/CircuitBreakerController.java
@@ -1,0 +1,40 @@
+package halo.corebridge.jobpostingread.controller;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/circuit-breakers")
+@RequiredArgsConstructor
+public class CircuitBreakerController {
+
+    private final CircuitBreakerRegistry circuitBreakerRegistry;
+
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> getCircuitBreakerStatus() {
+        Map<String, Object> result = new HashMap<>();
+
+        circuitBreakerRegistry.getAllCircuitBreakers().forEach(cb -> {
+            CircuitBreaker.Metrics metrics = cb.getMetrics();
+            Map<String, Object> status = new HashMap<>();
+            status.put("state", cb.getState().name());
+            status.put("failureRate", metrics.getFailureRate());
+            status.put("slowCallRate", metrics.getSlowCallRate());
+            status.put("numberOfSuccessfulCalls", metrics.getNumberOfSuccessfulCalls());
+            status.put("numberOfFailedCalls", metrics.getNumberOfFailedCalls());
+            status.put("numberOfNotPermittedCalls", metrics.getNumberOfNotPermittedCalls());
+            status.put("numberOfBufferedCalls", metrics.getNumberOfBufferedCalls());
+            result.put(cb.getName(), status);
+        });
+
+        return ResponseEntity.ok(result);
+    }
+}

--- a/backend/service/jobposting-read/src/main/resources/application.yml
+++ b/backend/service/jobposting-read/src/main/resources/application.yml
@@ -46,3 +46,47 @@ logging:
 # Outbox (소비자 서비스 - 비활성화)
 outbox:
   enabled: false
+
+# Resilience4j Circuit Breaker
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        registerHealthIndicator: true
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        failureRateThreshold: 50
+        slowCallRateThreshold: 80
+        slowCallDurationThreshold: 3s
+        waitDurationInOpenState: 30s
+        permittedNumberOfCallsInHalfOpenState: 3
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+        recordExceptions:
+          - org.springframework.web.client.RestClientException
+          - java.io.IOException
+          - java.util.concurrent.TimeoutException
+    instances:
+      jobpostingService:
+        baseConfig: default
+      userService:
+        baseConfig: default
+      commentService:
+        baseConfig: default
+      viewService:
+        baseConfig: default
+      likeService:
+        baseConfig: default
+
+# Actuator - Circuit Breaker 상태 노출
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, circuitbreakers, metrics
+  endpoint:
+    health:
+      show-details: always
+  health:
+    circuitbreakers:
+      enabled: true


### PR DESCRIPTION
## 📋 PR 유형
- [x] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 테스트 추가 (test)
- [ ] 설정/빌드 (chore)

## 🎯 작업 내용
jobposting-read 서비스에 Resilience4j Circuit Breaker 적용

### 신규 파일
- `CircuitBreakerEventConfig.java`: 상태 전환 로깅 (CLOSED→OPEN→HALF_OPEN→CLOSED)
- `CircuitBreakerController.java`: 5개 인스턴스 상태/메트릭 조회 API

### 변경 파일
- 5개 Client: `@CircuitBreaker` + fallback 메서드 추가 (user, jobposting, view, like, comment)
- `application.yml`: Resilience4j 설정 (slidingWindowSize=10, failureRate=50%, waitDuration=30s)
- `SecurityConfig.java`: `/api/v1/circuit-breakers/**` permitAll
- `build.gradle`: resilience4j-spring-boot3, spring-boot-starter-aop, actuator 추가

### 버그 수정
- **UserClient CGLIB self-invocation**: `getNickname()`이 같은 클래스의 `read()`를 내부 호출하여 프록시 우회 → `@CircuitBreaker` fallback 미동작. 독립 HTTP 호출 + 개별 `@CircuitBreaker` 적용으로 해결

## 🔗 관련 이슈

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [x] 코드 컨벤션 준수

## 📸 스크린샷
- 5개 인스턴스 CLOSED 상태 확인 (curl /api/v1/circuit-breakers)
- user 서비스 다운 → CLOSED→OPEN 전환 + fallback "익명" 반환
- 30초 후 OPEN→HALF_OPEN→CLOSED 자동 복구

<img width="1503" height="979" alt="스크린샷 2026-02-08 오후 8 12 52" src="https://github.com/user-attachments/assets/1e8148c3-364d-475e-a302-6102dd86e8ed" />
